### PR TITLE
Fix Parsing of First Param in Optional Params

### DIFF
--- a/Ingestion/templates/python.ecs.template.yaml
+++ b/Ingestion/templates/python.ecs.template.yaml
@@ -541,7 +541,7 @@ Resources:
             - !If 
               - UseOptionalEnvVar01
               - Name: !Select [0, !Split ["=", !Ref OptionalEnvVars]]
-                Value: !Select [1, !Split ["=", !Select [0, !Split [",", !Ref OptionalSecrets]]]]
+                Value: !Select [1, !Split ["=", !Select [0, !Split [",", !Ref OptionalEnvVars]]]]
               - !Ref "AWS::NoValue"
             - !If 
               - UseOptionalEnvVar02

--- a/Ingestion/templates/python.ecs.template.yaml
+++ b/Ingestion/templates/python.ecs.template.yaml
@@ -479,7 +479,7 @@ Resources:
             - !If 
               - UseOptionalSecret01
               - Name: !Select [0, !Split ["=", !Ref OptionalSecrets]]
-                ValueFrom: !Select [1, !Split ["=", !Ref OptionalSecrets]]
+                ValueFrom: !Select [1, !Split ["=", !Select [0, !Split [",", !Ref OptionalSecrets]]]]
               - !Ref "AWS::NoValue"
             - !If 
               - UseOptionalSecret02
@@ -541,7 +541,7 @@ Resources:
             - !If 
               - UseOptionalEnvVar01
               - Name: !Select [0, !Split ["=", !Ref OptionalEnvVars]]
-                Value: !Select [1, !Split ["=", !Ref OptionalEnvVars]]
+                Value: !Select [1, !Split ["=", !Select [0, !Split [",", !Ref OptionalSecrets]]]]
               - !Ref "AWS::NoValue"
             - !If 
               - UseOptionalEnvVar02


### PR DESCRIPTION
# What Changed?

Upon closer observation (thank you, @amanda-ruby), we realized there was an issue in parsing the first optional environment variable in the `OptionalEnvVars` param string.

Let us assume we were passing `OptionalEnvVars = "A=B,C=D"`. In this case, the environment variable `A` was being set to `B,C` as opposed to the correct `B`. The original parsing logic for the first variable only works if the `OptionalEnvVars` string has one variable. But, when there is more than one, the parsing fails.

I also used this as an opportunity to update the similar parsing logic for the first secret in the `OptionalSecrets` param string. Same story - works when there is only one secret (which is why we didn't detect the bug earlier), but would fail with more than one secret.