### PR TITLE
fix: Make DataHubAccessToken truly optional

### DIFF
--- a/Ingestion/templates/python.ecs.template.yaml
+++ b/Ingestion/templates/python.ecs.template.yaml
@@ -65,6 +65,7 @@ Parameters:
   DataHubAccessToken:
     Type: "String"
     NoEcho: true
+    Default: ""
     Description: "DataHub Personal Access Token. If not specified, we'll get it from ExistingDataHubAccessTokenSecretArn"
   ExecutorId:
     Type: "String"


### PR DESCRIPTION
## Context
The Remote Executor CloudFormation template supports two ways of passing in a DataHub Personal Access Token (PAT).

1. Pass in the token directly using the `DataHubAccessToken` parameter, letting the CloudFormation template create an AWS Secret for it.
**OR**
2. Create an AWS Secret for the DataHub PAT outside of the CloudFormation template, and pass in that secret's Amazon Resource Name (ARN) using the `ExistingDataHubAccessTokenSecretArn` parameter.

While NYT initially opted for 1, we decided to switch to 2. This lets us manage the secret in Terraform and leverage Terraform's lifecycle rules to reboot the Remote Executor when the token changes.

## The Bug
DataHubAccessToken is not truly optional.

## The Fix
We added a `Default` to the `DataHubAccessToken` parameter to make it optional.

## Credits
Thank you to @anaghshineh for helping me track this down in a marathon debug session!