### PR TITLE
Add outputs to cloud formation

### DIFF
--- a/Ingestion/templates/python.ecs.template.yaml
+++ b/Ingestion/templates/python.ecs.template.yaml
@@ -611,3 +611,14 @@ Resources:
             - !Ref SubnetID
           SecurityGroups:
             - !GetAtt ContainerSecurityGroup.GroupId
+
+Outputs:
+  ClusterName:
+    Description: Name of ECS Cluster
+    Value: !Ref Cluster
+  ECSLogGroupName:
+    Description: Name of ECS Cluster Log Group
+    Value: !Ref LogGroup
+  ServiceName:
+    Description: Name of ECS Service
+    Value: !GetAtt ECSService.Name


### PR DESCRIPTION
This PR adds an outputs field to the Cloud Formation Template which allows us to retrieve the cluster name, service name, and log group name that pertain to the Datahub Connector. This would enable our team to reference these values and point to the proper resources while using Terraform to set up our CloudWatch monitoring. 