### PR TITLE
Remove NoEcho option from Parameter

### DIFF
--- a/Ingestion/templates/python.ecs.template.yaml
+++ b/Ingestion/templates/python.ecs.template.yaml
@@ -70,7 +70,6 @@ Parameters:
     Description: "DataHub Base Url, for example: https://xxx.acryl.io/gms"
   DataHubAccessToken:
     Type: "String"
-    NoEcho: true
     Default: ""
     Description: "DataHub Personal Access Token. If not specified, we'll get it from ExistingDataHubAccessTokenSecretArn"
   ExecutorId:


### PR DESCRIPTION
The NoEcho option on the DataHubAccessToken prevents the parameter from being accessible in resources within the Cloudformation template. This bugfix removes the NoEcho option which makes the parameter accessible but with the tradeoff that the token is accessible as plain text within the AWS context. While this bugfix stabilizes a failing template, an alternative solution which better handles secret values should be next steps.